### PR TITLE
Fixing typo  in create_tomcat_admin_user.sh

### DIFF
--- a/4.1/create_tomcat_admin_user.sh
+++ b/4.1/create_tomcat_admin_user.sh
@@ -9,7 +9,7 @@ fi
 PASS=${TOMCAT_PASS:-$(pwgen -s 12 1)}
 _word=$( [ ${TOMCAT_PASS} ] && echo "preset" || echo "random" )
 
-echo "=> Creating and admin user with a ${_word} password in Tomcat"
+echo "=> Creating an admin user with a ${_word} password in Tomcat"
 sed -i -r 's/<\/tomcat-users>//' ${CATALINA_HOME}/conf/tomcat-users.xml
 echo '<role rolename="manager"/>' >> ${CATALINA_HOME}/conf/tomcat-users.xml
 echo '<role rolename="admin"/>' >> ${CATALINA_HOME}/conf/tomcat-users.xml

--- a/5.5/create_tomcat_admin_user.sh
+++ b/5.5/create_tomcat_admin_user.sh
@@ -9,7 +9,7 @@ fi
 PASS=${TOMCAT_PASS:-$(pwgen -s 12 1)}
 _word=$( [ ${TOMCAT_PASS} ] && echo "preset" || echo "random" )
 
-echo "=> Creating and admin user with a ${_word} password in Tomcat"
+echo "=> Creating an admin user with a ${_word} password in Tomcat"
 sed -i -r 's/<\/tomcat-users>//' ${CATALINA_HOME}/conf/tomcat-users.xml
 echo '<role rolename="manager-gui"/>' >> ${CATALINA_HOME}/conf/tomcat-users.xml
 echo '<role rolename="manager-script"/>' >> ${CATALINA_HOME}/conf/tomcat-users.xml

--- a/6.0/create_tomcat_admin_user.sh
+++ b/6.0/create_tomcat_admin_user.sh
@@ -9,7 +9,7 @@ fi
 PASS=${TOMCAT_PASS:-$(pwgen -s 12 1)}
 _word=$( [ ${TOMCAT_PASS} ] && echo "preset" || echo "random" )
 
-echo "=> Creating and admin user with a ${_word} password in Tomcat"
+echo "=> Creating an admin user with a ${_word} password in Tomcat"
 sed -i -r 's/<\/tomcat-users>//' ${CATALINA_HOME}/conf/tomcat-users.xml
 echo '<role rolename="manager-gui"/>' >> ${CATALINA_HOME}/conf/tomcat-users.xml
 echo '<role rolename="manager-script"/>' >> ${CATALINA_HOME}/conf/tomcat-users.xml

--- a/7.0/create_tomcat_admin_user.sh
+++ b/7.0/create_tomcat_admin_user.sh
@@ -9,7 +9,7 @@ fi
 PASS=${TOMCAT_PASS:-$(pwgen -s 12 1)}
 _word=$( [ ${TOMCAT_PASS} ] && echo "preset" || echo "random" )
 
-echo "=> Creating and admin user with a ${_word} password in Tomcat"
+echo "=> Creating an admin user with a ${_word} password in Tomcat"
 sed -i -r 's/<\/tomcat-users>//' ${CATALINA_HOME}/conf/tomcat-users.xml
 echo '<role rolename="manager-gui"/>' >> ${CATALINA_HOME}/conf/tomcat-users.xml
 echo '<role rolename="manager-script"/>' >> ${CATALINA_HOME}/conf/tomcat-users.xml

--- a/8.0/create_tomcat_admin_user.sh
+++ b/8.0/create_tomcat_admin_user.sh
@@ -9,7 +9,7 @@ fi
 PASS=${TOMCAT_PASS:-$(pwgen -s 12 1)}
 _word=$( [ ${TOMCAT_PASS} ] && echo "preset" || echo "random" )
 
-echo "=> Creating and admin user with a ${_word} password in Tomcat"
+echo "=> Creating an admin user with a ${_word} password in Tomcat"
 sed -i -r 's/<\/tomcat-users>//' ${CATALINA_HOME}/conf/tomcat-users.xml
 echo '<role rolename="manager-gui"/>' >> ${CATALINA_HOME}/conf/tomcat-users.xml
 echo '<role rolename="manager-script"/>' >> ${CATALINA_HOME}/conf/tomcat-users.xml


### PR DESCRIPTION
"=> Creating an admin user with ..." instead of "=> Creating and admin user with ..."